### PR TITLE
Update url replace code for dupe check

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,9 @@ function gulpS3Replace(options) {
         Promise.all(promises).then(function (urls) {
 
           for (var i = 0; i < urls.length; i++) {
-            content = content.replace(urls[i].originalUrl, urls[i].publicUrl);
+            if (!content.includes(urls[i].publicUrl)) {
+              content = content.replace(new RegExp(urls[i].originalUrl, 'g'), urls[i].publicUrl);
+            }
           }
 
           file.contents = new Buffer(content);


### PR DESCRIPTION
Added a check to see if the publicURL actually exists, which means it has already been changed.
Swapped out the content.replace to use regex to capture all instances of an image (image used in multiple places)

Closes #1